### PR TITLE
Make Makefile more robust to building in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM funcy/dind
-
+FROM funcy/go
 WORKDIR /fnproject
-
 ADD completer-docker /fnproject/completer
-
 CMD ["/fnproject/completer"]

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ run: build
 
 
 COMPLETER_DIR := $(realpath $(dir $(firstword $(MAKEFILE_LIST))))
+CONTAINER_COMPLETER_DIR := /go/src/github.com/fnproject/completer
 
 IMAGE_REPO_USER ?= fnproject
 IMAGE_NAME ?= completer
@@ -33,11 +34,12 @@ IMAGE_VERSION ?= latest
 IMAGE_FULL = $(IMAGE_REPO_USER)/$(IMAGE_NAME):$(IMAGE_VERSION)
 IMAGE_LATEST = $(IMAGE_REPO_USER)/$(IMAGE_NAME):latest
 
-docker-test: protos $(shell find . -name *.go)
+docker-pull-image-funcy-go:
 	docker pull funcy/go:dev
-	docker run --rm -it -v $(COMPLETER_DIR):$(COMPLETER_DIR) -w $(COMPLETER_DIR) -e GOPATH=$(GOPATH) -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=1 funcy/go:dev go test -v $(GOPACKAGES)
 
-docker-build: $(GOFILES) docker-test
-	docker pull funcy/go:dev
-	docker run --rm -it -v $(COMPLETER_DIR):$(COMPLETER_DIR) -w $(COMPLETER_DIR) -e GOPATH=$(GOPATH) -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=1 funcy/go:dev go build -o completer-docker
+docker-test: protos docker-pull-image-funcy-go
+	docker run --rm -it -v $(COMPLETER_DIR):$(CONTAINER_COMPLETER_DIR) -w $(CONTAINER_COMPLETER_DIR) -e CGO_ENABLED=1 funcy/go:dev sh -c 'go test -v $$(go list ./...  | grep -v /vendor/)'
+
+docker-build: docker-test docker-pull-image-funcy-go
+	docker run --rm -it -v $(COMPLETER_DIR):$(CONTAINER_COMPLETER_DIR) -w $(CONTAINER_COMPLETER_DIR) -e CGO_ENABLED=1 funcy/go:dev go build -o completer-docker
 	docker build -t $(IMAGE_FULL) -f $(COMPLETER_DIR)/Dockerfile $(COMPLETER_DIR)


### PR DESCRIPTION
Previously if you hadn't set up your GOPATH on your host you would not
be able to build in docker, we've fixed this so that you can clone any
where and run a `make docker-build` and you will build a
`fnproject/completer` image