### PR TITLE
Fix typo in function name

### DIFF
--- a/persistence/sql_blob_store_test.go
+++ b/persistence/sql_blob_store_test.go
@@ -67,7 +67,7 @@ func givenEmptyBlobStore() BlobStore {
 func setupDb() *sqlx.DB {
 	resetTestDb()
 
-	db, err := CreateDBConnecection(testDbUrl())
+	db, err := CreateDBConnection(testDbUrl())
 	if err != nil {
 		panic(err)
 	}

--- a/persistence/sql_init.go
+++ b/persistence/sql_init.go
@@ -28,8 +28,8 @@ var tables = [...]string{`CREATE TABLE IF NOT EXISTS events (
 	 blob_data BLOB);`,
 }
 
-// CreateDBConnecection sets up a DB connection and ensures required tables exist
-func CreateDBConnecection(url *url.URL) (*sqlx.DB, error) {
+// CreateDBConnection sets up a DB connection and ensures required tables exist
+func CreateDBConnection(url *url.URL) (*sqlx.DB, error) {
 	driver := url.Scheme
 	switch driver {
 	case "mysql", "sqlite3":

--- a/persistence/sql_provider_test.go
+++ b/persistence/sql_provider_test.go
@@ -108,7 +108,7 @@ func getEventsForActor(provider ProviderState, actorName string, startIdx int) [
 
 func givenProvider(t *testing.T) ProviderState {
 	resetTestDb()
-	db, err := CreateDBConnecection(testDbUrl())
+	db, err := CreateDBConnection(testDbUrl())
 	require.NoError(t, err)
 	provider, err := NewSqlProvider(db, 0)
 	require.NoError(t, err)

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -117,7 +117,7 @@ func InitStorageFromEnv() (persistence.ProviderState, persistence.BlobStore, err
 		return persistence.NewInMemoryProvider(snapshotInterval), persistence.NewInMemBlobStore(), nil
 	}
 
-	dbConn, err := persistence.CreateDBConnecection(dbUrl)
+	dbConn, err := persistence.CreateDBConnection(dbUrl)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
I noticed a typo while reading the code of the sql persistence stuff.