### PR TITLE
Sharded graphs sender workaround

### DIFF
--- a/actor/api.go
+++ b/actor/api.go
@@ -189,7 +189,7 @@ func (m *actorManager) forwardRequest(req interface{}, timeout time.Duration) (i
 	future := supervisor.RequestFuture(req, timeout)
 	m.log.Debugf("Waiting for supervisor response (future pid=%s)", future.PID().Id)
 	r, err := future.Result()
-	m.log.Debugf("Obtained response from supervisor (future pid=%s, error=%v)", pid, err)
+	m.log.Debugf("Obtained response from supervisor (future pid=%s, error=%v)", future.PID().Id, err)
 	if err != nil {
 		return nil, err
 	}

--- a/actor/api.go
+++ b/actor/api.go
@@ -185,8 +185,11 @@ func (m *actorManager) forwardRequest(req interface{}, timeout time.Duration) (i
 		return nil, err
 	}
 
+	m.log.Debug("Making asynchronous request to supervisor")
 	future := supervisor.RequestFuture(req, timeout)
+	m.log.Debugf("Waiting for supervisor response (future pid=%s)", future.PID().Id)
 	r, err := future.Result()
+	m.log.Debugf("Obtained response from supervisor (future pid=%s, error=%v)", pid, err)
 	if err != nil {
 		return nil, err
 	}

--- a/actor/graph.go
+++ b/actor/graph.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"time"
 
+	"regexp"
+
 	"github.com/AsynkronIT/protoactor-go/actor"
 	protoPersistence "github.com/AsynkronIT/protoactor-go/persistence"
 	"github.com/fnproject/flow/graph"
@@ -12,7 +14,6 @@ import (
 	"github.com/fnproject/flow/persistence"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/sirupsen/logrus"
-	"regexp"
 )
 
 // TODO: read this from configuration!
@@ -110,6 +111,7 @@ func currentTimestamp() *timestamp.Timestamp {
 }
 
 func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
+	sender := context.Sender()
 	if !g.validateCmd(cmd, context) {
 		return
 	}
@@ -121,11 +123,11 @@ func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
 		event := &model.GraphCreatedEvent{GraphId: msg.GraphId, FunctionId: msg.FunctionId, Ts: currentTimestamp()}
 		g.PersistReceive(event)
 		g.initGraph(event)
-		context.Respond(&model.CreateGraphResponse{GraphId: msg.GraphId})
+		context.Tell(sender, &model.CreateGraphResponse{GraphId: msg.GraphId})
 
 	case *model.GetGraphStateRequest:
 		g.log.Debug("Get graph state")
-		context.Respond(g.createExternalState())
+		context.Tell(sender, g.createExternalState())
 
 	case *model.AddChainedStageRequest:
 		g.log.Debug("Adding chained stage")
@@ -141,7 +143,7 @@ func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
 			CallerId:     msg.CallerId,
 		})
 
-		context.Respond(&model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
+		context.Tell(sender, &model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
 
 	case *model.AddCompletedValueStageRequest:
 		g.log.Debug("Adding completed value stage")
@@ -160,7 +162,7 @@ func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
 			Result:  msg.Result,
 			Ts:      currentTimestamp(),
 		})
-		context.Respond(&model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
+		context.Tell(sender, &model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
 
 	case *model.AddDelayStageRequest:
 		g.log.Debug("Adding delay stage")
@@ -180,7 +182,7 @@ func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
 		}
 		g.PersistReceive(delayEvent)
 		g.scheduleDelay(delayEvent)
-		context.Respond(&model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
+		context.Tell(sender, &model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
 
 	case *model.AddExternalCompletionStageRequest:
 		g.log.Debug("Adding external completion stage")
@@ -193,7 +195,7 @@ func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
 			CodeLocation: msg.CodeLocation,
 			CallerId:     msg.CallerId,
 		})
-		context.Respond(&model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
+		context.Tell(sender, &model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
 
 	case *model.AddInvokeFunctionStageRequest:
 		g.log.Debug("Adding invoke stage")
@@ -224,7 +226,7 @@ func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
 			FunctionId: realFunctionID,
 			Arg:        msg.Arg,
 		}, g.GetSelf())
-		context.Respond(&model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
+		context.Tell(sender, &model.AddStageResponse{GraphId: msg.GraphId, StageId: stageID})
 
 	case *model.CompleteStageExternallyRequest:
 		g.log.WithFields(logrus.Fields{"stage_id": msg.StageId}).Debug("Completing stage externally")
@@ -237,25 +239,25 @@ func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
 				Ts:      currentTimestamp(),
 			})
 		}
-		context.Respond(&model.CompleteStageExternallyResponse{GraphId: msg.GraphId, StageId: msg.StageId, Successful: completable})
+		context.Tell(sender, &model.CompleteStageExternallyResponse{GraphId: msg.GraphId, StageId: msg.StageId, Successful: completable})
 
 	case *model.CommitGraphRequest:
 		response := &model.GraphRequestProcessedResponse{GraphId: msg.GraphId}
 		if g.graph.IsCommitted() {
 			// idempotent
-			context.Respond(response)
+			context.Tell(sender, response)
 			return
 		}
 		g.log.Debug("Committing graph")
 		g.persistAndUpdateGraph(&model.GraphCommittedEvent{GraphId: msg.GraphId, Ts: currentTimestamp()})
-		context.Respond(response)
+		context.Tell(sender, response)
 
 	case *model.GetStageResultRequest:
 		g.log.WithFields(logrus.Fields{"stage_id": msg.StageId}).Debug("Retrieving stage result")
 		stage := g.graph.GetStage(msg.StageId)
 		context.AwaitFuture(stage.WhenComplete(), func(result interface{}, err error) {
 			if err != nil {
-				context.Respond(model.NewStageCompletionError(msg.GraphId, msg.StageId))
+				context.Tell(sender, model.NewStageCompletionError(msg.GraphId, msg.StageId))
 				return
 			}
 			response := &model.GetStageResultResponse{
@@ -263,7 +265,7 @@ func (g *graphActor) receiveCommand(cmd model.Command, context actor.Context) {
 				StageId: msg.StageId,
 				Result:  result.(*model.CompletionResult),
 			}
-			context.Respond(response)
+			context.Tell(sender, response)
 		})
 
 	case *model.CompleteDelayStageRequest:


### PR DESCRIPTION
Preserve the sender PID (pull it out of the context) in order to reply to the correct future.