### PR TITLE
Stop actor.Context being overwritten on SnapshotRequest

### DIFF
--- a/actor/api.go
+++ b/actor/api.go
@@ -185,11 +185,8 @@ func (m *actorManager) forwardRequest(req interface{}, timeout time.Duration) (i
 		return nil, err
 	}
 
-	m.log.Debug("Making asynchronous request to supervisor")
 	future := supervisor.RequestFuture(req, timeout)
-	m.log.Debugf("Waiting for supervisor response (future pid=%s)", future.PID().Id)
 	r, err := future.Result()
-	m.log.Debugf("Obtained response from supervisor (future pid=%s, error=%v)", future.PID().Id, err)
 	if err != nil {
 		return nil, err
 	}

--- a/persistence/receiver.go
+++ b/persistence/receiver.go
@@ -5,8 +5,9 @@ package persistence
   This has been modified to support propagating event indices to plugins
 */
 import (
-	"github.com/AsynkronIT/protoactor-go/actor"
 	"reflect"
+
+	"github.com/AsynkronIT/protoactor-go/actor"
 )
 
 // Using adds the persistence provider to a given actor
@@ -23,6 +24,11 @@ func Using(provider Provider) func(next actor.ActorFunc) actor.ActorFunc {
 				}
 			default:
 				next(ctx)
+				if p, ok := ctx.Actor().(persistent); ok {
+					if p.isSnapshotRequested() {
+						p.sendSnapshotRequest()
+					}
+				}
 			}
 		}
 		return fn


### PR DESCRIPTION
The persistence plugin interrupts the processing of an actor message when sending a SnapshotRequest message. This overwrites the actor.Context, breaking atomicity and consistency guarantees with respect to the actor message handling logic. SnapshotRequest messages should instead only be sent after the main actor function has finished processing the message that triggers a snapshot.