### PR TITLE
Simplify external completion to single call, remove old externalCompletion  /complete & /fail behaviour 

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -87,7 +87,7 @@ func (m *Manager) resolveNode(graphID string) (int, error) {
 		return -1, err
 	}
 	nodeIndex := shard % m.settings.NodeCount
-	log.WithField("graph_id", graphID).WithField("cluster_shard", shard).Info("Resolved shard")
+	log.WithField("graph_id", graphID).WithField("cluster_shard", shard).Debug("Resolved shard")
 	return nodeIndex, nil
 }
 
@@ -100,7 +100,7 @@ func (m *Manager) shouldForward(c *gin.Context) (bool, string) {
 
 	nodeIndex, err := m.resolveNode(graphID)
 	nodeName := m.settings.nodeName(nodeIndex)
-	log.WithField("graph_id", graphID).WithField("cluster_node", nodeName).Info("Resolved node")
+	log.WithField("graph_id", graphID).WithField("cluster_node", nodeName).Debug("Resolved node")
 	if err != nil {
 		log.Info(fmt.Sprintf("Failed to resolve node for graphId %s: %v", graphID, err))
 		return false, ""
@@ -123,14 +123,14 @@ func (m *Manager) ProxyHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		forward, node := m.shouldForward(c)
 		if !forward {
-			log.Info("Processing request locally")
+			log.Debug("Processing request locally")
 			return
 		}
 		graphID := extractGraphID(c)
 		log.WithField("graph_id", graphID).
 			WithField("proxy_node", node).
 			WithField("proxy_url", c.Request.URL.String()).
-			Info("Proxying graph request")
+			Debug("Proxying graph request")
 
 		if err := m.forward(c.Writer, c.Request, node); err != nil {
 			// TODO should we retry if this fails? buffer requests while upstream is unavailable?

--- a/docs/API.md
+++ b/docs/API.md
@@ -408,9 +408,8 @@ We'll swagger this up at some point
 | /graph/${graph_id}/allOf?cids=c1,c2,c3									| POST 		 | Adds a stage to this flow's graph that is completed with an empty value when all of the referenced stages complete successfully (or at least one completes exceptionally). Analogous to CompletableFuture's `allOf`. |
 | /graph/${graph_id}/anyOfcids=c1,c2,c3									| POST 	| Adds a stage to this flow's graph that is completed when at least one of the referenced stages completes successfully (or at least one completes exceptionally). This stage's completion value will be equal to that of the first completed referenced stage. Analogous to CompletableFuture's `anyOf`. |
 | /graph/${graph_id}/externalCompletion						| POST 			| Adds a root stage to this flow's graph that can be completed or failed externally via an HTTP post to `/graph/${graph_id}/stage/${stage_id}/complete` or `/graph/${graph_id}/stage/${stage_id}/fail`. Analogous to creating an empty CompletableFuture. |
-| /graph/${graph_id}/stage/${stage_id}						| GET 			| | datum | Blocks waiting for the given stage to complete, returning the associated value or error if executed exceptionally. |
-| /graph/${graph_id}/stage/${stage_id}/complete				| POST 			| Completes an `externalCompletion` stage successfully with the value provided in the HTTP request body. Analogous to CompletableFuture's `complete`.|
-| /graph/${graph_id}/stage/${stage_id}/fail					| POST 			| Completes an `externalCompletion` stage exceptionally with the error provided in the HTTP request body. Analogous to CompletableFuture's `completeExceptionally`.|
+| /graph/${graph_id}/stage/${stage_id}						| GET 			| Blocks waiting for the given stage to complete, returning the associated value or error if executed exceptionally. |
+| /graph/${graph_id}/stage/${stage_id}/complete				| POST 			| Completes a pending  stage  with a specified datum.  Analogous to CompletableFuture's `complete` and `completeExceptionally`. |
 | /graph/${graph_id}/stage/${stage_id}/acceptEither?other=${other_stage}			| POST 	 | Analogous to the [CompletionStage operation of the same name](https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/CompletionStage.html#acceptEither-java.util.concurrent.CompletionStage-java.util.function.Consumer-). |
 | /graph/${graph_id}/stage/${stage_id}/applyToEither?other=${other_stage}		| POST  | Analogous to the [CompletionStage operation of the same name](https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/CompletionStage.html#applyToEither-java.util.concurrent.CompletionStage-java.util.function.Function-). |
 | /graph/${graph_id}/stage/${stage_id}/thenAcceptBoth?other=${other_stage}		| POST 		 | Analogous to the [CompletionStage operation of the same name](https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/CompletionStage.html#thenAcceptBoth-java.util.concurrent.CompletionStage-java.util.function.BiConsumer-). |
@@ -547,6 +546,5 @@ Custom-Header: SomeOtherValue
 |allOf|when all of the parent stages completes|complete with null/void|complete with error|Completes on trigger - see execution strategies|
 |anyOf|when any of the parent stages completes|complete with parent result|complete with error|Completes on trigger - see execution strategies|
 |value|immediately|complete with literal value|complete with error|Completes on trigger - see execution strategies|
-|externally completable|externally via http callback|complete with external value provided in http request|complete with error|Completes on trigger - see execution strategies|
 |delay|externally by timer|complete with null/void once timer elapses|complete with error|Completes on trigger - see execution strategies|
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -443,9 +443,6 @@ func (graph *CompletionGraph) ValidateCommand(cmd model.Command) model.Validatio
 		if stage == nil {
 			return model.NewStageNotFoundError(msg.GraphId, msg.StageId)
 		}
-		if stage.GetOperation() != model.CompletionOperation_externalCompletion {
-			return model.NewStageNotCompletableError(msg.GraphId, msg.StageId)
-		}
 
 	case *model.GetStageResultRequest:
 		if valid := graph.validateStages(append(make([]string, 0), msg.StageId)); !valid {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -246,7 +246,7 @@ func (graph *CompletionGraph) handleStageCompleted(event *model.StageCompletedEv
 // handleInvokeComplete is signaled when an invocation (or function call) associated with a stage is completed
 // This may signal completion of the stage (in which case a Complete Event is raised)
 func (graph *CompletionGraph) handleInvokeComplete(event *model.FaasInvocationCompletedEvent) {
-	log.WithField("stage_id", event.StageId).Info("Completing stage with faas response")
+	log.WithField("fn_call_id",event.CallId).WithField("stage_id", event.StageId).Info("Completing stage with faas response")
 	stage := graph.stages[event.StageId]
 	stage.handleResult(graph, event.Result)
 }

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -54,4 +54,14 @@ var (
 	ErrInvalidContentType = &BadProtoMessage{
 		message: "Unsupported content type for datum",
 	}
+
+	// ErrMissingResultStatus -no result status header in request
+	ErrMissingResultStatus = &BadProtoMessage{
+		message: "Missing " + HeaderResultStatus + " header",
+	}
+
+	// ErrInvalidResultStatus bad format of result status
+	ErrInvalidResultStatus = &BadProtoMessage{
+		message: "Invalid " + HeaderResultStatus + " header",
+	}
 )

--- a/protocol/read.go
+++ b/protocol/read.go
@@ -34,13 +34,13 @@ func CompletionResultFromRequest(store persistence.BlobStore, req *http.Request)
 	resultStatusHeader := req.Header.Get(HeaderResultStatus)
 	var success bool
 	if resultStatusHeader == "" {
-		success = true
-	} else {
-		success, err = statusFromHeader(resultStatusHeader)
-		if err != nil {
-			return nil, err
-		}
+		return nil, ErrMissingResultStatus
 	}
+	success, err = statusFromHeader(resultStatusHeader)
+	if err != nil {
+		return nil, err
+	}
+
 	return &model.CompletionResult{
 		Successful: success,
 		Datum:      datum,
@@ -54,7 +54,7 @@ func statusFromHeader(statusString string) (bool, error) {
 	case ResultStatusFailure:
 		return false, nil
 	default:
-		return false, fmt.Errorf("Invalid result status header %s: \"%s\" ", HeaderResultStatus, statusString)
+		return false, ErrInvalidResultStatus
 	}
 }
 

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -93,34 +93,34 @@ func TestDirectCompletion(t *testing.T) {
 		ThenPOST("/graph/:graphID/stage/:stageID/complete").
 		With(emptyDatumInRequest).
 		WithHeaders(map[string]string{
-		protocol.HeaderResultStatus: "baah",
-	}).ExpectRequestErr(protocol.ErrInvalidResultStatus)
+			protocol.HeaderResultStatus: "baah",
+		}).ExpectRequestErr(protocol.ErrInvalidResultStatus)
 
 	tc.StartWithGraph("Completes External Completion Successfully").
 		ThenPOST("/graph/:graphID/externalCompletion").
 		ExpectStageCreated().
 		ThenPOST("/graph/:graphID/stage/:stageID/complete").
 		With(emptyDatumInRequest).
-		WithHeaders(map[string]string{"fnproject-resultstatus": "success",}).
+		WithHeaders(map[string]string{"fnproject-resultstatus": "success"}).
 		ExpectStatus(200).
 		ExpectLastStageEvent(func(ctx *testCtx, msg model.Event) {
-		evt, ok := msg.(*model.StageCompletedEvent)
-		require.True(ctx, ok)
-		assert.True(ctx, evt.Result.Successful)
-	})
+			evt, ok := msg.(*model.StageCompletedEvent)
+			require.True(ctx, ok)
+			assert.True(ctx, evt.Result.Successful)
+		})
 
 	tc.StartWithGraph("Completes External Completion With Failure").
 		ThenPOST("/graph/:graphID/externalCompletion").
 		ExpectStageCreated().
 		ThenPOST("/graph/:graphID/stage/:stageID/complete").
 		With(emptyDatumInRequest).
-		WithHeaders(map[string]string{"fnproject-resultstatus": "failure",}).
+		WithHeaders(map[string]string{"fnproject-resultstatus": "failure"}).
 		ExpectStatus(200).
 		ExpectLastStageEvent(func(ctx *testCtx, msg model.Event) {
-		evt, ok := msg.(*model.StageCompletedEvent)
-		require.True(ctx, ok)
-		assert.False(ctx, evt.Result.Successful)
-	})
+			evt, ok := msg.(*model.StageCompletedEvent)
+			require.True(ctx, ok)
+			assert.False(ctx, evt.Result.Successful)
+		})
 
 	tc.StartWithGraph("Conflicts on already completed stage ").
 		ThenPOST("/graph/:graphID/externalCompletion").
@@ -131,8 +131,8 @@ func TestDirectCompletion(t *testing.T) {
 		ThenPOST("/graph/:graphID/stage/:stageID/complete").
 		With(emptyDatumInRequest).
 		WithHeaders(map[string]string{
-		"fnproject-resultstatus": "failure",
-	}).ExpectStatus(409)
+			"fnproject-resultstatus": "failure",
+		}).ExpectStatus(409)
 
 	StageAcceptsMetadata(func(s string) *APICmd {
 		return tc.StartWithGraph(s).
@@ -255,23 +255,23 @@ func StageAcceptsErrorType(s func(string) *APICmd) {
 	s("Rejects missing error type").
 		WithBodyString("str").
 		WithHeaders(map[string]string{
-		"fnproject-datumtype": "error",
-		"content-type":        "text/plain"}).
+			"fnproject-datumtype": "error",
+			"content-type":        "text/plain"}).
 		WithBodyString("body").ExpectRequestErr(protocol.ErrMissingErrorType)
 
 	s("Rejects missing content type").
 		WithBodyString("str").
 		WithHeaders(map[string]string{
-		"fnproject-datumtype": "error",
-		"fnproject-errortype": "error"}).
+			"fnproject-datumtype": "error",
+			"fnproject-errortype": "error"}).
 		WithBodyString("body").ExpectRequestErr(protocol.ErrMissingContentType)
 
 	s("Rejects non-text content type").
 		WithBodyString("str").
 		WithHeaders(map[string]string{
-		"fnproject-datumtype": "error",
-		"fnproject-errortype": "error",
-		"content-type":        "application/octet-stream"}).
+			"fnproject-datumtype": "error",
+			"fnproject-errortype": "error",
+			"content-type":        "application/octet-stream"}).
 		WithBodyString("body").ExpectRequestErr(protocol.ErrInvalidContentType)
 
 	s("Accepts valid error datum").WithBodyString("str").WithErrorDatum(model.ErrorDatumType_name[int32(model.ErrorDatumType_invalid_stage_response)], "msg").ExpectStageCreated()
@@ -286,8 +286,8 @@ func StageAcceptsEmptyType(s func(string) *APICmd) {
 	s("Accepts empty datum").
 		WithBodyString("str").
 		WithHeaders(map[string]string{
-		"fnproject-datumtype": "empty",
-		"content-type":        "text/plain"}).
+			"fnproject-datumtype": "empty",
+			"content-type":        "text/plain"}).
 		WithBodyString("body").ExpectStageCreated()
 
 }
@@ -299,10 +299,10 @@ func StageAcceptsHTTPReqType(s func(string) *APICmd) {
 	s("Accepts httpreq datum").
 		WithBodyString("str").
 		WithHeaders(map[string]string{
-		"fnproject-datumtype": "httpreq",
-		"fnproject-method":    "get",
+			"fnproject-datumtype": "httpreq",
+			"fnproject-method":    "get",
 
-		"content-type": "text/plain"}).
+			"content-type": "text/plain"}).
 		WithBodyString("body").ExpectStageCreated()
 
 }
@@ -314,9 +314,9 @@ func StageAcceptsHTTPRespType(s func(string) *APICmd) {
 	s("Accepts httpresp datum").
 		WithBodyString("str").
 		WithHeaders(map[string]string{
-		"fnproject-datumtype":  "httpresp",
-		"fnproject-resultcode": "100",
-		"content-type":         "text/plain"}).
+			"fnproject-datumtype":  "httpresp",
+			"fnproject-resultcode": "100",
+			"content-type":         "text/plain"}).
 		WithBodyString("body").ExpectStageCreated()
 
 }
@@ -326,19 +326,19 @@ func StageAcceptsMetadata(s func(string) *APICmd) {
 	s("Works with no metadata ").
 		ExpectStageCreated().
 		ExpectLastStageAddedEvent(func(ctx *testCtx, event *model.StageAddedEvent) {
-		assert.Equal(ctx, "", event.CodeLocation)
-		assert.Equal(ctx, "", event.CallerId)
-	})
+			assert.Equal(ctx, "", event.CodeLocation)
+			assert.Equal(ctx, "", event.CallerId)
+		})
 
 	s("Works with no metadata ").
 		WithHeader(protocol.HeaderCodeLocation, "code-loc").
 		WithHeader(protocol.HeaderCallerRef, "caller-id").
 		ExpectStageCreated().
 		ExpectLastStageAddedEvent(func(ctx *testCtx, event *model.StageAddedEvent) {
-		assert.Equal(ctx, "code-loc", event.CodeLocation)
-		assert.Equal(ctx, "caller-id", event.CallerId)
+			assert.Equal(ctx, "code-loc", event.CodeLocation)
+			assert.Equal(ctx, "caller-id", event.CallerId)
 
-	})
+		})
 
 }
 

--- a/sanity/testlib.go
+++ b/sanity/testlib.go
@@ -120,20 +120,20 @@ func (c *APICmd) ExpectStatus(status int) *APICmd {
 func (c *APICmd) ExpectGraphCreated() *APICmd {
 	return c.ExpectStatus(200).
 		Expect(func(ctx *testCtx, resp *http.Response) {
-		flowIDHeader := resp.Header.Get("Fnproject-FlowId")
-		require.NotEmpty(ctx, flowIDHeader, "FlowId header must be present in headers %v ", resp.Header)
-		ctx.graphID = flowIDHeader
-	}, "Graph was created")
+			flowIDHeader := resp.Header.Get("Fnproject-FlowId")
+			require.NotEmpty(ctx, flowIDHeader, "FlowId header must be present in headers %v ", resp.Header)
+			ctx.graphID = flowIDHeader
+		}, "Graph was created")
 }
 
 // ExpectStageCreated verifies that the server reported that  a stage was created
 func (c *APICmd) ExpectStageCreated() *APICmd {
 	return c.ExpectStatus(200).
 		Expect(func(ctx *testCtx, resp *http.Response) {
-		stage := resp.Header.Get("Fnproject-StageId")
-		require.NotEmpty(ctx, stage, "StageID not in header")
-		ctx.stageID = stage
-	}, "Stage was created")
+			stage := resp.Header.Get("Fnproject-StageId")
+			require.NotEmpty(ctx, stage, "StageID not in header")
+			ctx.stageID = stage
+		}, "Stage was created")
 }
 
 // ExpectLastStageAddedEvent  adds an expectation on the last StageAddedEvent

--- a/server/server.go
+++ b/server/server.go
@@ -154,7 +154,11 @@ func (s *Server) handleStageOperation(c *gin.Context) {
 			return
 		}
 		c.Header(protocol.HeaderStageRef, response.StageId)
-		c.Status(http.StatusOK)
+		if response.Successful {
+			c.Status(http.StatusOK)
+		} else {
+			c.String(http.StatusBadRequest, "Stage is already completed")
+		}
 	case "completeExceptionally":
 		response, err := s.completeWithResultStatus(graphID, stageID, c.Request, false)
 		if err != nil {
@@ -162,7 +166,11 @@ func (s *Server) handleStageOperation(c *gin.Context) {
 			return
 		}
 		c.Header(protocol.HeaderStageRef, response.StageId)
-		c.Status(http.StatusOK)
+		if response.Successful {
+			c.Status(http.StatusOK)
+		} else {
+			c.String(http.StatusBadRequest, "Stage is already completed")
+		}
 	default:
 		other := c.Query("other")
 		cids := []string{stageID}


### PR DESCRIPTION
The intent of this is to allow stages (and their dependents) of all stage types to be cancelled, as described in #108.

This removes the check that a stage referenced by an external completion request is an external completion, so that all stages can be completed externally. Two new resources are added so that a stage can be completed externally, with any datum type, either normally or exceptionally. If the stage is already completed, then the server will respond with a HTTP 400 response.

As with any stage that completes exceptionally, the dependents of a stage will be executed exceptionally, so that unless (or until) a stage of type `exceptionally` or `handle` is reached, the effect is to cancel the execution of a stage and its dependents. 

Note: A difference with the corresponding `cancel` method on `java.util.concurrent.CompletableFuture` is that this implementation doesn't provide a way to interrupt the execution of an already running stage.

The two existing resources for completing an externally completable stage, `complete` and `fail`, are left unchanged, as these are specifically used for completing a stage with an HTTP request. The only difference to their behaviour is that they can now be used to complete *any* stage type (because the check is removed), but only with an httpreq datum for the result.