### PR TITLE
Add api metrics and quantiles

### DIFF
--- a/actor/executor.go
+++ b/actor/executor.go
@@ -15,9 +15,22 @@ import (
 	"github.com/fnproject/flow/persistence"
 	"github.com/fnproject/flow/protocol"
 	"github.com/sirupsen/logrus"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const fnCallIDHeader = "Fn_call_id"
+
+var (
+	activeFnCallsMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "flow_concurrent_active_fn_calls",
+		Help: "Current number of fn calls waiting for a response.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(activeFnCallsMetric)
+	activeFnCallsMetric.Set(0.0)
+}
 
 type graphExecutor struct {
 	faasAddr  string
@@ -92,6 +105,8 @@ func (exec *graphExecutor) HandleInvokeStage(msg *model.InvokeStageRequest) *mod
 	req.Header.Set("Content-type", fmt.Sprintf("multipart/form-data; boundary=\"%s\"", partWriter.Boundary()))
 	req.Header.Set(protocol.HeaderFlowID, msg.GraphId)
 	req.Header.Set(protocol.HeaderStageRef, msg.StageId)
+	activeFnCallsMetric.Inc()
+	defer activeFnCallsMetric.Dec()
 	resp, err := exec.client.Do(req)
 
 	if err != nil {
@@ -159,6 +174,8 @@ func (exec *graphExecutor) HandleInvokeFunction(msg *model.InvokeFunctionRequest
 		req.Header.Add(header.Key, header.Value)
 	}
 
+	activeFnCallsMetric.Inc()
+	defer activeFnCallsMetric.Dec()
 	resp, err := exec.client.Do(req)
 
 	if err != nil {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -10,6 +10,8 @@ import (
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/fnproject/flow/model"
 	"github.com/sirupsen/logrus"
+	"github.com/opentracing/opentracing-go"
+	"github.com/golang/protobuf/ptypes"
 )
 
 var log = logrus.WithField("logger", "graph")
@@ -61,6 +63,7 @@ type CompletionGraph struct {
 	// This is completed with the termination state
 	terminationRoot      *RawDependency
 	terminationChainHead *CompletionStage
+	startTime     time.Time
 }
 
 // New Creates a new graph
@@ -73,6 +76,7 @@ func New(id string, functionID string, listener CompletionEventListener) *Comple
 		log:             log.WithFields(logrus.Fields{"graph_id": id, "function_id": functionID}),
 		state:           StateInitial,
 		terminationRoot: &RawDependency{ID: "_termination"},
+		startTime:       time.Now(),
 	}
 }
 
@@ -114,6 +118,8 @@ func (graph *CompletionGraph) IsCompleted() bool {
 func (graph *CompletionGraph) handleCompleted() {
 	graph.log.Info("completing graph")
 	graph.state = StateCompleted
+	span := opentracing.StartSpan("graph_completion", opentracing.StartTime(graph.startTime))
+	span.Finish()
 }
 
 // handleTerminating completes the termination stage with a specified state,
@@ -353,6 +359,10 @@ func (graph *CompletionGraph) checkForExecutionFinished() {
 
 // UpdateWithEvent updates this graph's state acGetGraphStateRequestcording to the received event
 func (graph *CompletionGraph) UpdateWithEvent(event model.Event, mayTrigger bool) {
+	eventTime, _ := ptypes.Timestamp(event.GetTs())
+	if eventTime.Before(graph.startTime) {
+		graph.startTime = eventTime
+	}
 	switch e := event.(type) {
 	case *model.GraphCommittedEvent:
 		graph.handleCommitted()

--- a/server/prom_zip_collector.go
+++ b/server/prom_zip_collector.go
@@ -61,7 +61,7 @@ func (pc PrometheusCollector) Collect(span *zipkincore.Span) error {
 			prometheus.SummaryOpts{
 				Name: "flow_span_" + span.GetName() + "_duration_secs_summary",
 				Help: "Span " + span.GetName() + " duration, by span name",
-				Objectives: map[float64]float64 {0.5: 0.01, 0.75: 0.01, 0.9: 0.01, 0.99: 0.001},
+				Objectives: map[float64]float64 {0.5: 0.01, 0.9: 0.01, 0.99: 0.001},
 			},
 			labelKeysFromSpan,
 		)

--- a/server/prom_zip_collector.go
+++ b/server/prom_zip_collector.go
@@ -22,11 +22,19 @@ type PrometheusCollector struct {
 	// In this map, the key is the name of a tracing span,
 	// and the corresponding value is an array containing the label keys that were specified when the HistogramVec metric was created
 	registeredLabelKeysMap map[string][]string
+
+	// In this map, the key is the name of a tracing span,
+	// and the corresponding value is a SummaryVec metric which is useful to compute the quantiles of the duration of spans
+	summaryVecMap map[string]*prometheus.SummaryVec
 }
 
 // NewPrometheusCollector returns a new PrometheusCollector
 func NewPrometheusCollector() (zipkintracer.Collector, error) {
-	pc := &PrometheusCollector{make(map[string]*prometheus.HistogramVec), make(map[string][]string)}
+	pc := &PrometheusCollector{
+		make(map[string]*prometheus.HistogramVec),
+	make(map[string][]string),
+		make(map[string]*prometheus.SummaryVec),
+	}
 	return pc, nil
 }
 
@@ -38,28 +46,39 @@ func (pc PrometheusCollector) Collect(span *zipkincore.Span) error {
 	labelKeysFromSpan, labelValuesFromSpan := getLabels(span)
 
 	// get the HistogramVec for this span name
-	histogramVec, found := pc.histogramVecMap[span.GetName()]
+	expectedLabelKeys, found := pc.registeredLabelKeysMap[span.GetName()]
 	if !found {
 		// create a new HistogramVec
-		histogramVec = prometheus.NewHistogramVec(
+		histogramVec := prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name: "fn_span_" + span.GetName() + "_duration_seconds",
+				Name: "flow_span_" + span.GetName() + "_duration_secs_histogram",
 				Help: "Span " + span.GetName() + " duration, by span name",
 			},
 			labelKeysFromSpan,
 		)
+		// create a new SummaryVec
+		summaryVec := prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Name: "flow_span_" + span.GetName() + "_duration_secs_summary",
+				Help: "Span " + span.GetName() + " duration, by span name",
+				Objectives: map[float64]float64 {0.5: 0.01, 0.75: 0.01, 0.9: 0.01, 0.99: 0.001},
+			},
+			labelKeysFromSpan,
+		)
 		pc.histogramVecMap[span.GetName()] = histogramVec
-		pc.registeredLabelKeysMap[span.GetName()] = labelKeysFromSpan
 		prometheus.MustRegister(histogramVec)
+		pc.summaryVecMap[span.GetName()] = summaryVec
+		prometheus.MustRegister(summaryVec)
+		pc.registeredLabelKeysMap[span.GetName()] = labelKeysFromSpan
 		labelValuesToUse = labelValuesFromSpan
 	} else {
-		// found an existing HistogramVec
+		// found an existing span name
 		// need to be careful here, since we must supply the same label keys as when we first created the metric
 		// otherwise we will get a "inconsistent label cardinality" panic
 		// that's why we saved the original label keys in the registeredLabelKeysMap map
 		// so we can use that to construct a map of label key/value pairs to set on the metric
 		labelValuesToUse = make(map[string]string)
-		for _, thisRegisteredLabelKey := range pc.registeredLabelKeysMap[span.GetName()] {
+		for _, thisRegisteredLabelKey := range expectedLabelKeys {
 			if value, found := labelValuesFromSpan[thisRegisteredLabelKey]; found {
 				labelValuesToUse[thisRegisteredLabelKey] = value
 			} else {
@@ -69,7 +88,8 @@ func (pc PrometheusCollector) Collect(span *zipkincore.Span) error {
 	}
 
 	// now report the metric value
-	histogramVec.With(labelValuesToUse).Observe((time.Duration(span.GetDuration()) * time.Microsecond).Seconds())
+	pc.histogramVecMap[span.GetName()].With(labelValuesToUse).Observe((time.Duration(span.GetDuration()) * time.Microsecond).Seconds())
+	pc.summaryVecMap[span.GetName()].With(labelValuesToUse).Observe((time.Duration(span.GetDuration()) * time.Microsecond).Seconds())
 
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -74,11 +74,6 @@ func (s *Server) handleStageOperation(c *gin.Context) {
 		renderError(ErrInvalidStageID, c)
 		return
 	}
-	body, err := c.GetRawData()
-	if err != nil {
-		renderError(ErrReadingInput, c)
-		return
-	}
 
 	switch operation {
 
@@ -113,6 +108,11 @@ func (s *Server) handleStageOperation(c *gin.Context) {
 
 		}
 
+		body, err := c.GetRawData()
+		if err != nil {
+			renderError(ErrReadingInput, c)
+			return
+		}
 		blob, err := s.BlobStore.CreateBlob(c.ContentType(), body)
 		if err != nil {
 			renderError(err, c)

--- a/server/server.go
+++ b/server/server.go
@@ -88,6 +88,10 @@ func (s *Server) completeExternally(graphID string, stageID string, body []byte,
 }
 
 func (s *Server) handleStageOperation(c *gin.Context) {
+	operation := c.Param(paramOperation)
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "stage:" + operation)
+	defer span.Finish()
 	graphID := c.Param(paramGraphID)
 	if !validGraphID(graphID) {
 		renderError(ErrInvalidGraphID, c)
@@ -98,7 +102,6 @@ func (s *Server) handleStageOperation(c *gin.Context) {
 		renderError(ErrInvalidStageID, c)
 		return
 	}
-	operation := c.Param(paramOperation)
 	body, err := c.GetRawData()
 	if err != nil {
 		renderError(ErrReadingInput, c)
@@ -189,6 +192,9 @@ func renderError(err error, c *gin.Context) {
 }
 
 func (s *Server) handleCreateGraph(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:create")
+	defer span.Finish()
 	log.Info("Creating graph")
 	functionID := c.Query(queryParamFunctionID)
 	graphID := c.Query(queryParamGraphID)
@@ -214,6 +220,9 @@ func (s *Server) handleCreateGraph(c *gin.Context) {
 }
 
 func (s *Server) handleGraphState(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:get")
+	defer span.Finish()
 
 	graphID := c.Param(paramGraphID)
 	if !validGraphID(graphID) {
@@ -239,6 +248,9 @@ func resultStatus(result *model.CompletionResult) string {
 }
 
 func (s *Server) handleGetGraphStage(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "stage:get")
+	defer span.Finish()
 	graphID := c.Param(paramGraphID)
 	stageID := c.Param(paramStageID)
 
@@ -374,6 +386,9 @@ func (s *Server) handleGetGraphStage(c *gin.Context) {
 }
 
 func (s *Server) handleExternalCompletion(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:externalCompletion")
+	defer span.Finish()
 	graphID := c.Param(paramGraphID)
 	if !validGraphID(graphID) {
 		renderError(ErrInvalidGraphID, c)
@@ -432,14 +447,23 @@ func (s *Server) allOrAnyOf(c *gin.Context, op model.CompletionOperation) {
 }
 
 func (s *Server) handleAllOf(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:allOf")
+	defer span.Finish()
 	s.allOrAnyOf(c, model.CompletionOperation_allOf)
 }
 
 func (s *Server) handleAnyOf(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:anyOf")
+	defer span.Finish()
 	s.allOrAnyOf(c, model.CompletionOperation_anyOf)
 }
 
 func (s *Server) handleSupply(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:supply")
+	defer span.Finish()
 	graphID := c.Param(paramGraphID)
 	if !validGraphID(graphID) {
 		renderError(ErrInvalidGraphID, c)
@@ -486,6 +510,9 @@ func (s *Server) handleSupply(c *gin.Context) {
 }
 
 func (s *Server) handleCompletedValue(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:completedValue")
+	defer span.Finish()
 	graphID := c.Param(paramGraphID)
 	if !validGraphID(graphID) {
 		renderError(ErrInvalidGraphID, c)
@@ -519,6 +546,10 @@ func (s *Server) addStage(request model.AddStageCommand) (*model.AddStageRespons
 }
 
 func (s *Server) handleCommit(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:commit")
+	defer span.Finish()
+
 	graphID := c.Param(paramGraphID)
 	request := model.CommitGraphRequest{GraphId: graphID}
 
@@ -533,6 +564,9 @@ func (s *Server) handleCommit(c *gin.Context) {
 }
 
 func (s *Server) handleDelay(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:delay")
+	defer span.Finish()
 	graphID := c.Param(paramGraphID)
 	if !validGraphID(graphID) {
 		renderError(ErrInvalidGraphID, c)
@@ -565,6 +599,9 @@ func (s *Server) handleDelay(c *gin.Context) {
 }
 
 func (s *Server) handleInvokeFunction(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:invokeFunction")
+	defer span.Finish()
 	graphID := c.Param(paramGraphID)
 	if !validGraphID(graphID) {
 		renderError(ErrInvalidGraphID, c)
@@ -606,6 +643,9 @@ func (s *Server) handleInvokeFunction(c *gin.Context) {
 }
 
 func (s *Server) handleAddTerminationHook(c *gin.Context) {
+	span := opentracing.StartSpan("api")
+	span.SetTag("fn_operation", "graph:addTerminationHook")
+	defer span.Finish()
 	graphID := c.Param(paramGraphID)
 	if !validGraphID(graphID) {
 		renderError(ErrInvalidGraphID, c)


### PR DESCRIPTION
This adds trivial API call duration metrics.

Also, this adds a "Summary" prometheus representation to every metric, allowing quantiles to be recorded in addition to the histogram view. This code should be backported into Fn as well.