### PR TITLE
Ensure a failed "make test" fails the build.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -exo pipefail
 
 if [[ -z "$TEST_RESULTS" ]]; then
   TEST_RESULTS=/tmp/test-results


### PR DESCRIPTION
Quick fix we picked up from last night's big merge.